### PR TITLE
Move map below charts

### DIFF
--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -1,19 +1,12 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import React from 'react'
 import './App.css'
 import Dashboard from './Dashboard'
 
-
 function App() {
-  const [count, setCount] = useState(0)
 
   return (
     <>
-    <Dashboard/>
-    
-     
-
+      <Dashboard/>
     </>
   )
 }

--- a/dashboard/src/Dashboard.jsx
+++ b/dashboard/src/Dashboard.jsx
@@ -141,8 +141,10 @@ export default function Dashboard() {
                             <div className="space-y-8">
                                 <PieChart byContinent={byContinent} statType={statType} />
                                 <BarChart byContinent={byContinent} statType={statType} />
-                                <Map pandemicId={selectedPandemic} statType={statType} />
                             </div>
+                        </div>
+                        <div className="w-full mt-8">
+                            <Map pandemicId={selectedPandemic} statType={statType} />
                         </div>
                     </section>
                 </div>

--- a/dashboard/src/components/Map.jsx
+++ b/dashboard/src/components/Map.jsx
@@ -32,7 +32,7 @@ export default function Map({ pandemicId, statType }) {
     });
 
     return (
-        <div className="w-full h-80">
+        <div className="w-full h-64 md:h-80 lg:h-96">
             <h2 className="text-2xl font-bold mb-2">Carte des {statType === 'daily_new_cases' ? 'cas quotidiens' : 'décès quotidiens'}</h2>
             {lons.length === 0 ? (
                 <p>Aucune donnée pour cette carte.</p>
@@ -51,7 +51,12 @@ export default function Map({ pandemicId, statType }) {
                     }]}
                     layout={{
                         geo: {
-                            projection: { type: 'natural earth' }
+                            projection: { type: 'natural earth' },
+                            bgcolor: '#1f2937',
+                            showland: true,
+                            showocean: true,
+                            landcolor: '#2d3748',
+                            oceancolor: '#1e293b'
                         },
                         paper_bgcolor: '#1f2937',
                         plot_bgcolor: '#1f2937',

--- a/dashboard/tailwind.config.js
+++ b/dashboard/tailwind.config.js
@@ -1,4 +1,7 @@
+/* eslint-env node */
 /** @type {import('tailwindcss').Config} */
+import tailwindcssAnimate from 'tailwindcss-animate'
+
 export default {
     darkMode: ["class"],
     content: [
@@ -59,5 +62,7 @@ export default {
   		}
   	}
   },
-  plugins: [require("tailwindcss-animate")],
+
+  plugins: [tailwindcssAnimate],
 }
+


### PR DESCRIPTION
## Summary
- move `Map` component under the chart grid to span full width
- tweak map styling for dark mode and responsive height
- clean unused imports in `App.jsx`
- adjust Tailwind config to use ESM import
- run lint

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685327b8ce308322aaeb321d18312570