### PR TITLE
Replace daily bar chart with prediction chart

### DIFF
--- a/dashboard/src/Dashboard.jsx
+++ b/dashboard/src/Dashboard.jsx
@@ -30,6 +30,7 @@ export default function Dashboard() {
 
     // Données journalières
     const [dailyData, setDailyData] = useState([]);
+    const [predictionData, setPredictionData] = useState([]);
 
     // Agrégation par continent
     const [byContinent, setByContinent] = useState([]);
@@ -91,6 +92,18 @@ export default function Dashboard() {
             .catch(err => console.error("Erreur dailyData:", err));
     }, [selectedCountry, selectedPandemic, startDate, endDate]);
 
+    // Récupérer les prédictions pour le graphique en barre
+    useEffect(() => {
+        if (!selectedCountry || !selectedPandemic) {
+            setPredictionData([]);
+            return;
+        }
+        const type = statType === 'daily_new_cases' ? 'cases' : 'deaths';
+        axios.get(`http://127.0.0.1:5000/predict/${type}/${selectedCountry}/${selectedPandemic}`)
+            .then(res => setPredictionData(res.data))
+            .catch(err => console.error('Erreur predictions:', err));
+    }, [selectedCountry, selectedPandemic, statType]);
+
     // Récupérer l'agrégation par continent
     useEffect(() => {
         axios.get(`http://127.0.0.1:5000/pandemic_country/continent`)
@@ -136,7 +149,7 @@ export default function Dashboard() {
                         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
                             <div className="space-y-8">
                                 <LineChart dailyData={dailyData} statType={statType} />
-                                <Histogram dailyData={dailyData} statType={statType} />
+                                <Histogram predictionData={predictionData} statType={statType} />
                             </div>
                             <div className="space-y-8">
                                 <PieChart byContinent={byContinent} statType={statType} />

--- a/dashboard/src/components/Histogram.jsx
+++ b/dashboard/src/components/Histogram.jsx
@@ -1,21 +1,25 @@
 import React from 'react';
 import Plot from 'react-plotly.js';
 
-export default function Histogram({ dailyData, statType }) {
+export default function Histogram({ predictionData, statType }) {
     return (
         <div>
             <h2 className="text-2xl font-bold mb-2">
-                Histogramme : {statType === 'daily_new_cases' ? 'Cas quotidiens' : 'Décès quotidiens'}
+                Prédictions 7 jours : {statType === 'daily_new_cases' ? 'Cas quotidiens' : 'Décès quotidiens'}
             </h2>
-            {dailyData.length === 0 ? (
+            {predictionData.length === 0 ? (
                 <p>Aucune donnée pour cet histogramme.</p>
             ) : (
                 <div className="w-full h-64 md:h-80 lg:h-96">
                     <Plot
                         data={[
                             {
-                                x: dailyData.map(d => d.date),
-                                y: dailyData.map(d => d[statType] || 0),
+                                x: predictionData.map(d => d.date),
+                                y: predictionData.map(d =>
+                                    statType === 'daily_new_cases'
+                                        ? d.predicted_cases || 0
+                                        : d.predicted_deaths || 0
+                                ),
                                 type: 'bar',
                                 marker: { color: 'tomato' }
                             }


### PR DESCRIPTION
## Summary
- update Histogram component to show predicted cases or deaths
- fetch prediction data in Dashboard and show in histogram

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853375bb7b883229ea6077fc04b37af